### PR TITLE
Fix links to rootlesscontainers.proto

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -140,7 +140,7 @@ system calls to work.</p></li>
   which executes them, syscalls like <code>chown(2)</code> and <code>mknod(2)</code> actually
   modify persistent storage and thus rootless container runtimes may wish
   to persist this data in a interoperable fashion. For this purpose we define
-  <a href="https://github.com/cyphar/rootlesscontaine.rs/tree/master/proto/rootlesscontainers.proto">the <code>user.rootlesscontainers</code> <code>xattr</code> attribute</a>.
+  <a href="https://github.com/rootless-containers/rootlesscontaine.rs/blob/f7b0f5486bb0e0be75771ce50c54471296f040eb/docs/proto/rootlesscontainers.proto">the <code>user.rootlesscontainers</code> <code>xattr</code> attribute</a>.
   This is also useful for emulating &ldquo;real root&rdquo; with tools like <a href="https://proot-me.github.io">PRoot</a>
   or <a href="https://github.com/cyphar/remainroot">remainroot</a>. <a href="https://github.com/AkihiroSuda/runrootless">runROOTLESS</a> provides a forked
   version of PRoot that implements the <code>user.rootlesscontainers</code> <code>xattr</code>

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -124,7 +124,7 @@ box][runc-rootless]. The main restrictions are the following:
 [runc-pr1540]: https://github.com/opencontainers/runc/pull/1540
 [lxcfs]: https://github.com/lxc/lxcfs
 [aleksa-20160627]: https://www.cyphar.com/blog/post/20160627-rootless-containers-with-runc
-[rootlesscontainers-proto]: https://github.com/cyphar/rootlesscontaine.rs/tree/master/proto/rootlesscontainers.proto
+[rootlesscontainers-proto]: https://github.com/rootless-containers/rootlesscontaine.rs/blob/f7b0f5486bb0e0be75771ce50c54471296f040eb/docs/proto/rootlesscontainers.proto
 [proot]: https://proot-me.github.io
 [remainroot]: https://github.com/cyphar/remainroot
 [runrootless]: https://github.com/AkihiroSuda/runrootless


### PR DESCRIPTION
And lock them to a commit in case they wander off again.