### PR TITLE
add a banner for the 2020 edition

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -5,7 +5,7 @@
 <meta name="description" content="">
 <meta name="keywords" content="">
 <meta name="author" content="Aleksa Sarai">
-<meta name="generator" content="Hugo 0.53" />
+<meta name="generator" content="Hugo 0.78.1" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://rootlesscontaine.rs/css/style.css" type="text/css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700" type="text/css">

--- a/docs/categories/index.html
+++ b/docs/categories/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="">
 <meta name="keywords" content="">
 <meta name="author" content="Aleksa Sarai">
-<meta name="generator" content="Hugo 0.53" />
+<meta name="generator" content="Hugo 0.78.1" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://rootlesscontaine.rs/css/style.css" type="text/css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700" type="text/css">

--- a/docs/categories/index.xml
+++ b/docs/categories/index.xml
@@ -1,14 +1,10 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Categories on Rootless Containers</title>
     <link>https://rootlesscontaine.rs/categories/</link>
     <description>Recent content in Categories on Rootless Containers</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>en-us</language>
-    
-	<atom:link href="https://rootlesscontaine.rs/categories/index.xml" rel="self" type="application/rss+xml" />
-    
-    
+    <language>en-us</language><atom:link href="https://rootlesscontaine.rs/categories/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="">
 <meta name="keywords" content="">
 <meta name="author" content="Aleksa Sarai">
-<meta name="generator" content="Hugo 0.53" />
+<meta name="generator" content="Hugo 0.78.1" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://rootlesscontaine.rs/css/style.css" type="text/css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700" type="text/css">
@@ -31,36 +31,29 @@
   <article class="single" itemscope itemtype="http://schema.org/BlogPosting">
     <h1 class="headline" itemprop="headline">Rootless Containers</h1>
     <section class="body" itemprop="articleBody">
-      
-
+      <h1 id="-2020-edition-is-coming-soon">🟡 2020 edition is coming soon</h1>
+<p>The 2020 edition of our website is currently WIP.</p>
+<p>See <a href="https://github.com/rootless-containers/rootlesscontaine.rs/pull/19">https://github.com/rootless-containers/rootlesscontaine.rs/pull/19</a> for
+the latest contents under review.</p>
+<hr>
 <h2 id="overview">Overview</h2>
-
 <p>Rootless containers refers to the ability for an unprivileged user to create,
 run and otherwise manage containers. This term also includes the variety of
 tooling around containers that can also be run as an unprivileged user. The
 goal of this website is to catalogue all of the open questions and unresolved
 issues that need to be solved to bring us closer to rootless containers &ldquo;for
 all&rdquo;.</p>
-
 <p>&ldquo;Unprivileged user&rdquo; in this context refers to a user who does not have any
 administrative rights, and is &ldquo;not in the good graces of the administrator&rdquo; (in
 other words, they do not have the ability to ask for more privileges to be
 granted to them, or for software packages to be installed).</p>
-
-<p><iframe src="https://www.slideshare.net/slideshow/embed_code/key/nJyXOTcSJaz0cL" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <a href="https://www.slideshare.net/AkihiroSuda/rootless-containers" title="Rootless Containers" target="_blank">Our talk at DevConf.cz 2019</a></div></p>
-
-<hr />
-
-<h1 id="outdated-contents">⚠️ OUTDATED CONTENTS ⚠️</h1>
-
+<iframe src="https://www.slideshare.net/slideshow/embed_code/key/nJyXOTcSJaz0cL" width="595" height="485" frameborder="0" marginwidth="0" marginheight="0" scrolling="no" style="border:1px solid #CCC; border-width:1px; margin-bottom:5px; max-width: 100%;" allowfullscreen> </iframe> <div style="margin-bottom:5px"> <a href="https://www.slideshare.net/AkihiroSuda/rootless-containers" title="Rootless Containers" target="_blank">Our talk at DevConf.cz 2019</a></div>
+<hr>
+<h1 id="-outdated-contents-">⚠️ OUTDATED CONTENTS ⚠️</h1>
 <p>The following contents are outdated and planned to be updated.</p>
-
 <p>For a while, please refer to the slide deck above.</p>
-
 <h3 id="objectives">Objectives</h3>
-
 <p>The objectives of this project are to allow an unprivileged user to:</p>
-
 <ul>
 <li>(<strong><code>O0</code></strong>) Create, run, and manage containers on their local machine.</li>
 <li>(<strong><code>O1</code></strong>) Create, modify, distribute, and extract container images on their
@@ -68,25 +61,20 @@ local machine so they may run said container images through (<strong><code>O0</c
 <li>(<strong><code>O2</code></strong>) Create, manage, and use a container orchestrator on either their
 local machine (effective a single-node cluster) or on a set of machines they
 would ordinarily be able to communicate with and run unprivileged programs
-on.
-<!-- If you're reading this and want to add to the above list, please open a PR! --></li>
+on.</li>
 </ul>
-
+<!-- If you're reading this and want to add to the above list, please open a PR! -->
 <p>While security is not a primary objective of this project (the goal is user
 enablement), the intention is that any kernel-level improvements required to
 facilitate this project will involve collaboration with the <a href="https://containerhardening.org/">Linux Container
 Hardening Project</a>. We hope that the end result is that rootless
 containers will be secure as well as useful, thus allowing enterprises to
 support this usage of containers.</p>
-
 <h2 id="status">Status</h2>
-
 <p>This is a living document, as is maintained by humans. If you wish to add more
 entries to this list, or have an update on a particular section, please <a href="https://github.com/cyphar/rootlesscontaine.rs">open a
 pull request</a>.</p>
-
 <h3 id="o0-runtime">(<code>O0</code>) Runtime</h3>
-
 <ul>
 <li><input type="checkbox" disabled checked> Support rootless containers in a
 standardised container runtime.</li>
@@ -108,13 +96,12 @@ allegory for Jessie&rsquo;s awesome <a href="https://github.com/jessfraz/dockerf
 using rootless containers (she <a href="https://blog.jessfraz.com/post/ultimate-linux-on-the-desktop/">actually uses them as well</a>
 but some more descriptive documentation would really help).</li>
 </ul>
-
 <p>The de-facto implementation of the Open Container Initiative&rsquo;s runtime
 specification, <a href="https://github.com/opencontainers/runc"><code>runc</code></a>, supports rootless containers <a href="https://github.com/opencontainers/runc/pull/774">out of the
 box</a>. The main restrictions are the following:</p>
-
 <ul>
-<li><p><code>cgroups</code> are not supported in the general case, because on the kernel side,
+<li>
+<p><code>cgroups</code> are not supported in the general case, because on the kernel side,
 unprivileged subtree management has not been implemented. There is a new
 <code>nsdelegate</code> mount option for the <strong>host</strong> cgroup mount (which allows for
 sub-tree delegation of cgroupv2 when you create a cgroup namespace), but
@@ -122,13 +109,15 @@ since <code>runc</code> supports neither cgroupv2 nor cgroup namespaces this fea
 not useful to us at the moment. However, <a href="https://github.com/opencontainers/runc/pull/1540">recently</a> <code>runc</code> can
 opportunistically use cgroups if the system was configured to allow users to
 use them (see <a href="https://github.com/lxc/lxcfs"><code>lxcfs</code>&rsquo;s PAM module</a> for an example of how such a
-system can be configured).</p></li>
-
-<li><p><a href="https://criu.org/Main_Page"><code>criu</code></a> supports unprivileged dumping (<code>checkpoint</code>) but <code>restore</code> is
+system can be configured).</p>
+</li>
+<li>
+<p><a href="https://criu.org/Main_Page"><code>criu</code></a> supports unprivileged dumping (<code>checkpoint</code>) but <code>restore</code> is
 not supported and the <code>checkpoint</code>ing aspects have not been well tested in
-the context of rootless containers.</p></li>
-
-<li><p>Network namespaces aren&rsquo;t used in most cases because currently unprivileged
+the context of rootless containers.</p>
+</li>
+<li>
+<p>Network namespaces aren&rsquo;t used in most cases because currently unprivileged
 network namespaces are not very useful (in the standard usage of containers)
 because a new network namespace doesn&rsquo;t have any network interfaces (other
 than <code>lo</code>). The standard way of linking network namespaces (<code>veth</code> bridges)
@@ -137,27 +126,26 @@ containers. Some ideas for solving this are to implement unprivileged <code>veth
 bridges in the kernel, or to implement some sort of unprivileged userspace
 <code>veth</code> bridge implementation with <a href="https://github.com/AkihiroSuda/runrootless/tree/f1c2e886d07b280ae1558d04cfe074aa6889a9a4/misc/vde">TAP</a>. The jury
 is out on this one at the moment, so we just use the host&rsquo;s network namespace
-and call it a day.</p></li>
-
-<li><p>Some system calls such as <code>setgroups(2)</code>, <code>seteuid(2)</code>, and <code>chown(2)</code> are
+and call it a day.</p>
+</li>
+<li>
+<p>Some system calls such as <code>setgroups(2)</code>, <code>seteuid(2)</code>, and <code>chown(2)</code> are
 <a href="https://www.cyphar.com/blog/post/20160627-rootless-containers-with-runc">known not to work</a> in rootless containers, unless multiple
 UID/GID mappings are configured with SUID utility binaries (<code>newuidmap(1)</code>,
 <code>newgidmap(1)</code>). Programs such as <code>apt</code> and <code>yum</code> are known to require such
-system calls to work.</p></li>
+system calls to work.</p>
+</li>
 </ul>
-
 <p>While <code>setgroups(2)</code> and <code>seteuid(2)</code> are only &ldquo;temporary&rdquo; for the process
-  which executes them, syscalls like <code>chown(2)</code> and <code>mknod(2)</code> actually
-  modify persistent storage and thus rootless container runtimes may wish
-  to persist this data in a interoperable fashion. For this purpose we define
-  <a href="https://github.com/rootless-containers/rootlesscontaine.rs/blob/f7b0f5486bb0e0be75771ce50c54471296f040eb/docs/proto/rootlesscontainers.proto">the <code>user.rootlesscontainers</code> <code>xattr</code> attribute</a>.
-  This is also useful for emulating &ldquo;real root&rdquo; with tools like <a href="https://proot-me.github.io">PRoot</a>
-  or <a href="https://github.com/cyphar/remainroot">remainroot</a>. <a href="https://github.com/rootless-containers/runrootless">runROOTLESS</a> provides a forked
-  version of PRoot that implements the <code>user.rootlesscontainers</code> <code>xattr</code>
-  attribute.</p>
-
+which executes them, syscalls like <code>chown(2)</code> and <code>mknod(2)</code> actually
+modify persistent storage and thus rootless container runtimes may wish
+to persist this data in a interoperable fashion. For this purpose we define
+<a href="https://github.com/rootless-containers/rootlesscontaine.rs/blob/f7b0f5486bb0e0be75771ce50c54471296f040eb/docs/proto/rootlesscontainers.proto">the <code>user.rootlesscontainers</code> <code>xattr</code> attribute</a>.
+This is also useful for emulating &ldquo;real root&rdquo; with tools like <a href="https://proot-me.github.io">PRoot</a>
+or <a href="https://github.com/cyphar/remainroot">remainroot</a>. <a href="https://github.com/rootless-containers/runrootless">runROOTLESS</a> provides a forked
+version of PRoot that implements the <code>user.rootlesscontainers</code> <code>xattr</code>
+attribute.</p>
 <h3 id="o1-images">(<code>O1</code>) Images</h3>
-
 <ul>
 <li><input type="checkbox" disabled checked> Add support to a tool for creating
 and modifying standardised container images as an unprivileged user.</li>
@@ -178,11 +166,9 @@ implementation to operate as an unprivileged user. This is separate from
 everything to a directory) works in principle but is not as efficient as
 using filesystem features to reduce the footprint of extracted images.</li>
 </ul>
-
 <p>These requirements are implemented by several different tools, that each solve
 a piece of the puzzle. These tools can then be combined to create a
 &ldquo;full-fledged&rdquo; implementation of an image store or handler.</p>
-
 <p>Distribution is the simplest problem to solve in this respect, and is
 accomplished by <a href="https://github.com/projectatomic/skopeo"><code>skopeo</code></a>. In principle an Open Container Initiative
 image can just be copied with <code>rsync</code>, but <code>skopeo</code> also has several features
@@ -190,90 +176,85 @@ related to conversion between different image formats that makes it incredibly
 useful for a variety of other tasks. <code>skopeo</code> does not require privileges for
 any of this core functionality (and in fact, is normally used as an
 unprivileged user).</p>
-
 <p>Extraction, modification, and creation are implemented by <a href="https://umo.ci/"><code>umoci</code></a>. The
 main issue with these operations is the limitations of the filesystem as an
 unprivileged user, since there are a wide variety of operations that are not
 permitted (for security reasons). As a result, <code>umoci</code>&rsquo;s rootless support comes
 with some caveats:</p>
-
 <ul>
-<li><p>While <code>umoci</code> will recreate the precise (or as close as possible) root
+<li>
+<p>While <code>umoci</code> will recreate the precise (or as close as possible) root
 filesystem state of the container image as a privileged user, as an
 unprivileged user certain hacks are required. Examples include creating dummy
 files in place of device nodes that an unprivileged user cannot create, and
 forcing everything to be owned by the current unprivileged user. As a result,
 the results of the image extraction may be counter-intuitive, but a lot of
-work has gone into reducing the weirdness of these hacks. In addition, <code>umoci
-repack</code> is implemented in such a way that it should not (in normal usage)
+work has gone into reducing the weirdness of these hacks. In addition, <code>umoci repack</code> is implemented in such a way that it should not (in normal usage)
 result in an image that has <code>umoci</code>&rsquo;s hacks baked into it (if you run an
 image modified by an unprivileged user as a privileged user it should work
 normally). However, <code>umoci</code> supports the usage of the previously mentioned
 <a href="https://github.com/rootless-containers/rootlesscontaine.rs/blob/f7b0f5486bb0e0be75771ce50c54471296f040eb/docs/proto/rootlesscontainers.proto"><code>user.rootlesscontainers</code> <code>xattr</code> attribute</a>,
 which means that programs that accept <code>user.rootlesscontainers</code> attributes
-will be able to interoperate correctly.</p></li>
-
-<li><p>Because of how discretionary access control works, <code>umoci</code> may have to modify
+will be able to interoperate correctly.</p>
+</li>
+<li>
+<p>Because of how discretionary access control works, <code>umoci</code> may have to modify
 the root filesystem of an extracted image when doing &ldquo;read-only&rdquo; operations
 on the extracted image. This means that root filesystems on <code>read-only</code> media
-(while <code>umoci</code> is operating on them) may run into issues.</p></li>
+(while <code>umoci</code> is operating on them) may run into issues.</p>
+</li>
 </ul>
-
 <p>Building of images is implemented by <a href="https://github.com/cyphar/orca-build"><code>orca-build</code></a>, which is a
 proof-of-concept wrapper around <code>runc</code>, <code>umoci</code>, and <code>skopeo</code>. There are
 several other container builder projects which may implement this feature in
 the future, but right now <code>orca-build</code> is fast enough and is quite minimal. It
 also has the additional feature of being compatible with the <code>Dockerfile</code>
 format for specifying build steps.</p>
-
 <h3 id="o2-orchestration">(<code>O2</code>) Orchestration</h3>
-
 <p>Orchestration is currently the biggest unknown. It&rsquo;s not quite clear what is
 complete list of tasks necessary in order to make a container orchestrator run
 with the majority of its functionality working as an unprivileged user.</p>
-
 <ul>
 <li><input type="checkbox" disabled> Implement a way for a container networking
 interface plugin to run as an unprivileged user. This may involve just
-creating alternative plugins and swapping out the privileged versions.
-<!-- TODO: Extend these. --></li>
+creating alternative plugins and swapping out the privileged versions.</li>
 </ul>
-
+<!-- TODO: Extend these. -->
 <p>These tasks do not have much significant progress. However, Cloud Foundry have
 implemented <a href="https://github.com/cloudfoundry/garden-runc-release/blob/43a4aaf771a18173f1b57a8aec749d16433ad2a7/docs/rootless-containers.md">experimental rootless container support</a>. The
 downside to their implementation is that it still requires privileged setup
 steps, and a privileged networking binary during the container lifecycle
 (thus not making it truly rootless, but it&rsquo;s a great first step).</p>
-
 <h2 id="prior-art">Prior Art</h2>
-
 <!-- If we've missed your project, feel free to open a PR! -->
-
 <p>There has been some work in this space before, but (to our knowledge) nothing
 this ambitious. The following are a list of projects that have some kind of
 rootless container support.</p>
-
 <ul>
-<li><p><a href="https://github.com/projectatomic/bubblewrap"><code>bubblewrap</code></a> (formerly <code>xdg-app</code>) implements parts of a
+<li>
+<p><a href="https://github.com/projectatomic/bubblewrap"><code>bubblewrap</code></a> (formerly <code>xdg-app</code>) implements parts of a
 container runtime as an unprivileged user, but to our knowledge it doesn&rsquo;t
 implement enough of the Open Container Initiative standard (even with
-<a href="https://github.com/projectatomic/bwrap-oci"><code>bwrap-oci</code></a>) to be a full container runtime.</p></li>
-
-<li><p><a href="https://linuxcontainers.org/lxc/"><code>lxc</code></a> has implemented quite a substantial portion of rootless
+<a href="https://github.com/projectatomic/bwrap-oci"><code>bwrap-oci</code></a>) to be a full container runtime.</p>
+</li>
+<li>
+<p><a href="https://linuxcontainers.org/lxc/"><code>lxc</code></a> has implemented quite a substantial portion of rootless
 containers, but their implementation requires privileged helper binaries to
 set up <code>cgroups</code> and network interfaces. This is a reasonable compromise for
 a container runtime (and <code>runc</code>&rsquo;s solution was to just ignore those
 usecases), and <code>lxc</code> does have knobs to disable the use of those binaries,
 but it still means that it is still more of a hassle to use <code>lxc</code> in a way
-that would be required by this project.</p></li>
-
-<li><p><a href="https://github.com/jessfraz/binctr"><code>binctr</code></a> was a proof-of-concept written by <a href="https://blog.jessfraz.com/">Jessie
+that would be required by this project.</p>
+</li>
+<li>
+<p><a href="https://github.com/jessfraz/binctr"><code>binctr</code></a> was a proof-of-concept written by <a href="https://blog.jessfraz.com/">Jessie
 Frazelle</a> and was the inspiration for the upstream rootless
 container work in runc. It has the interesting additional feature of creating
 a single static binary that contains both the container runtime and the root
-filesystem of the container.</p></li>
-
-<li><p><a href="https://www.sylabs.io/"><code>singularity</code></a> was developed in parallel to the <code>runc</code>
+filesystem of the container.</p>
+</li>
+<li>
+<p><a href="https://www.sylabs.io/"><code>singularity</code></a> was developed in parallel to the <code>runc</code>
 implementation of rootless containers. It is a runtime that was developed for
 HPC requirements, and so has quite a few odd design desisions based on those
 requirements. However, one point of note is that in its default configuration
@@ -282,15 +263,12 @@ mounting the loopback device used as the rootfs), which make it impractical
 for the use-cases rootless containers were meant to solve. It appears that
 <code>singularity</code> does support user namespaces, but it&rsquo;s not clear whether a
 fully unprivileged setup is commonly used or has enough features to contend
-with <code>runc</code>&rsquo;s rootless containers.</p></li>
+with <code>runc</code>&rsquo;s rootless containers.</p>
+</li>
 </ul>
-
 <h2 id="faq">FAQ</h2>
-
 <!-- If there is a question that hasn't been answered here, please open a PR! -->
-
 <h3 id="who-are-we">Who are we?</h3>
-
 <p>At the moment, a party of one. But if this sounds cool to you, feel free to
 join me! I&rsquo;m on <a href="https://mastodon.social/@cyphar">Mastodon</a>, and can be reached
 at (<a href="mailto:cyphar@cyphar.com">cyphar@cyphar.com</a>).</p>

--- a/docs/index.xml
+++ b/docs/index.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Rootless Containers</title>
@@ -6,10 +6,6 @@
     <description>Recent content on Rootless Containers</description>
     <generator>Hugo -- gohugo.io</generator>
     <language>en-us</language>
-    <lastBuildDate>Fri, 07 Apr 2017 21:07:40 +1000</lastBuildDate>
-    
-	<atom:link href="https://rootlesscontaine.rs/index.xml" rel="self" type="application/rss+xml" />
-    
-    
+    <lastBuildDate>Fri, 07 Apr 2017 21:07:40 +1000</lastBuildDate><atom:link href="https://rootlesscontaine.rs/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
   
@@ -9,12 +9,10 @@
   
   <url>
     <loc>https://rootlesscontaine.rs/categories/</loc>
-    <priority>0</priority>
   </url>
   
   <url>
     <loc>https://rootlesscontaine.rs/tags/</loc>
-    <priority>0</priority>
   </url>
   
 </urlset>

--- a/docs/tags/index.html
+++ b/docs/tags/index.html
@@ -5,7 +5,7 @@
 <meta name="description" content="">
 <meta name="keywords" content="">
 <meta name="author" content="Aleksa Sarai">
-<meta name="generator" content="Hugo 0.53" />
+<meta name="generator" content="Hugo 0.78.1" />
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <link rel="stylesheet" href="https://rootlesscontaine.rs/css/style.css" type="text/css">
 <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700" type="text/css">

--- a/docs/tags/index.xml
+++ b/docs/tags/index.xml
@@ -1,14 +1,10 @@
-<?xml version="1.0" encoding="utf-8" standalone="yes" ?>
+<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
     <title>Tags on Rootless Containers</title>
     <link>https://rootlesscontaine.rs/tags/</link>
     <description>Recent content in Tags on Rootless Containers</description>
     <generator>Hugo -- gohugo.io</generator>
-    <language>en-us</language>
-    
-	<atom:link href="https://rootlesscontaine.rs/tags/index.xml" rel="self" type="application/rss+xml" />
-    
-    
+    <language>en-us</language><atom:link href="https://rootlesscontaine.rs/tags/index.xml" rel="self" type="application/rss+xml" />
   </channel>
 </rss>

--- a/site/config.toml
+++ b/site/config.toml
@@ -7,3 +7,7 @@ enableemoji = true
 
 [params]
 	Author = "Aleksa Sarai"
+
+# https://discourse.gohugo.io/t/raw-html-getting-omitted-in-0-60-0/22032
+[markup.goldmark.renderer]
+  unsafe= true

--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -5,6 +5,14 @@ draft = false
 
 +++
 
+# :yellow_circle: 2020 edition is coming soon #
+
+The 2020 edition of our website is currently WIP.
+
+See https://github.com/rootless-containers/rootlesscontaine.rs/pull/19 for
+the latest contents under review.
+
+- - -
 ## Overview ##
 
 Rootless containers refers to the ability for an unprivileged user to create,


### PR DESCRIPTION
@cyphar If reviewing #19 still takes a time, can we have a banner like this?

```console
$ git diff master site/content/
diff --git a/site/content/_index.md b/site/content/_index.md
index 90e9271..ad38ee0 100644
--- a/site/content/_index.md
+++ b/site/content/_index.md
@@ -5,6 +5,14 @@ draft = false
 
 +++
 
+# :yellow_circle: 2020 edition is coming soon #
+
+The 2020 edition of our website is currently WIP.
+
+See https://github.com/rootless-containers/rootlesscontaine.rs/pull/19 for
+the latest contents under review.
+
+- - -
 ## Overview ##
 
 Rootless containers refers to the ability for an unprivileged user to create,
```