### PR TITLE
kubernetes.md: update Usernetes instruction

### DIFF
--- a/content/getting-started/kubernetes.md
+++ b/content/getting-started/kubernetes.md
@@ -21,7 +21,7 @@ See https://github.com/rootless-containers/usernetes
 ```console
 $ tar xjvf usernetes-x86_64.tbz
 $ cd usernetes
-$ ./install.sh --cri=containerd --cgroup-manager=systemd
+$ ./install.sh --cri=containerd
 $ export KUBECONFIG="$HOME/.config/usernetes/master/admin-localhost.kubeconfig"
 $ kubectl apply -f manifests/*.yaml
 ```


### PR DESCRIPTION
Usernetes no longer needs `--cgroup-manager=systemd` to be specified manually