### PR TITLE
Rootless OverlayFS is officially supported since kernel 5.11

### DIFF
--- a/content/glossary/_index.md
+++ b/content/glossary/_index.md
@@ -30,6 +30,8 @@ A [FUSE](#fuse) implementation of OverlayFS.
 
 Web site: https://github.com/containers/fuse-overlayfs
 
+FUSE-OverlayFS is mostly used for allowing rootless OverlayFS on old kernels (< 5.11).
+
 See [How it works/OverlayFS](../how-it-works/overlayfs/).
 
 ## N

--- a/content/how-it-works/overlayfs.md
+++ b/content/how-it-works/overlayfs.md
@@ -3,8 +3,9 @@ title: OverlayFS
 weight: 30
 ---
 
+Rootless OverlayFS is supported since [kernel 5.11](https://github.com/torvalds/linux/commit/459c7c565ac36ba09ffbf24231147f408fde4203).
 
-The upstream kernel still doesn't support mounting OverlayFS inside [UserNS](../userns/),
+Older kernel releases didn't support rootless OverlayFS,
 though [Ubuntu](https://kernel.ubuntu.com/git/ubuntu/ubuntu-bionic.git/commit/fs/overlayfs?id=3b7da90f28fe1ed4b79ef2d994c81efbc58f1144)
 and [Debian](https://salsa.debian.org/kernel-team/linux/blob/283390e7feb21b47779b48e0c8eb0cc409d2c815/debian/patches/debian/overlayfs-permit-mounts-in-userns.patch)
 support it by patching the kernel.


### PR DESCRIPTION
https://github.com/torvalds/linux/commit/459c7c565ac36ba09ffbf24231147f408fde4203

Rootless OverlayFS (kernel mode) was previously only available for Ubuntu and Debian hosts.
