### PR TITLE
cgroup2.md: recommend rebooting after changing systemd config

### DIFF
--- a/content/getting-started/common/cgroup2.md
+++ b/content/getting-started/common/cgroup2.md
@@ -58,3 +58,6 @@ $ sudo systemctl daemon-reload
 ```
 
 Delegating `cpuset` is recommended as well as `cpu`. Delegating `cpuset` requires systemd 244 or later.
+
+After changing the systemd configuration, you need to re-login or reboot the host.
+Rebooting the host is recommended.


### PR DESCRIPTION
Running `systemctl daemon-reload` and relogging in seems not enough for Fedora 34.

See #32

