### PR TITLE
getting-started/common/login.md: ksu does not set $XDG_RUNTIME_DIR

### DIFF
--- a/content/getting-started/common/login.md
+++ b/content/getting-started/common/login.md
@@ -22,6 +22,7 @@ The `$XDG_RUNTIME_DIR` environmental variable is set when:
 The environmental variable is _not_ set when:
 * Logged in as the root, and then switched to a non-root user via `su -l <user>`
 * Logged in as the root, and then switched to a non-root user via `sudo -u <user>`
+* Logged in as the root, and then switched to a non-root user via `ksu <user>`
 
 {{< hint info >}}
 **TL;DR**


### PR DESCRIPTION
Closes https://github.com/rootless-containers/rootlesscontaine.rs/issues/44