### PR TITLE
Remove title from singularity page to remove it from leftside index

### DIFF
--- a/content/getting-started/singularity.md
+++ b/content/getting-started/singularity.md
@@ -1,6 +1,1 @@
----
-title: Singularity
-weight: 50
----
-
 Singularity has been renamed to [Apptainer](../apptainer), please see that page.


### PR DESCRIPTION
I had hoped that #52 would remove `Singularity` from the index on the left side of the web page, but it didn't.  I expect this will probably do it.  That link in the index is confusing since Singularity is now covered in the `Apptainer/Singularity` link.  The reason for leaving the .md file at all is for old hyperlinks elsewhere.